### PR TITLE
Fenced block configuration

### DIFF
--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -166,9 +166,17 @@ fun! s:lookup_fancy(id)
   return found[0]
 endf
 
+fun! s:search_forward(pattern)
+  return search(a:pattern, 'cnW')
+endf
+
+fun! s:search_backward(pattern)
+  return search(a:pattern, 'bcnW')
+endf
+
 fun! s:get_start_end_position()
-  let start = search('^```\w\+$', 'bcnW')
-  let end = search('^```$', 'cnW')
+  let start = s:search_backward('^```\w\+$')
+  let end = s:search_forward('^```$')
   return [start, end]
 endf
 

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -124,7 +124,7 @@ fun! s:fancy() abort
   let found = 0
   for search_options in candidates
     let [start_at, end_at] = s:get_region_bounds(search_options)
-    if start_at != 0 || end_at != 0
+    if start_at != 0 && end_at != 0
       let found = 1
       break
     endif

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -153,12 +153,10 @@ fun! s:fancy_sync() dict abort
 endf
 
 fun! s:fancy_filetype() dict abort
-  let pos = getpos('.')
-  let pos[2] = 0
-  call setpos('.', pos)
-
-  let text = join(self.buffer.read(self.start_at, self.start_at), '\n')
-  return substitute(text, '```', '', '')
+  let filetype = self.options.filetype(self)
+  return empty(filetype)
+        \ ? self.buffer.getvar('&filetype')
+        \ : filetype
 endf
 
 fun! s:fancy_text() dict abort

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -115,16 +115,31 @@ call s:add_methods('buffer', [
 let s:fancy_prototype = {}
 
 fun! s:fancy() abort
-  let [start, end] = s:get_start_end_position()
-  if start == 0 && end == 0
+  let candidates = s:get_filetype_options(&filetype)
+  if empty(candidates)
+    call s:error(printf('%s: no available search options', &filetype))
+    return
+  endif
+
+  let found = 0
+  for search_options in candidates
+    let [start_at, end_at] = s:get_region_bounds(search_options)
+    if start_at != 0 || end_at != 0
+      let found = 1
+      break
+    endif
+  endfor
+
+  if !found
     call s:error('No fenced block found! Aborting!')
     return
   endif
 
   let fancy = {
         \ 'id': s:get_id(),
-        \ 'start': start,
-        \ 'end': end,
+        \ 'options': search_options,
+        \ 'start_at': start_at,
+        \ 'end_at': end_at,
         \ 'buffer': s:buffer()
         \ }
   call extend(fancy, s:fancy_prototype, 'keep')
@@ -142,12 +157,12 @@ fun! s:fancy_filetype() dict abort
   let pos[2] = 0
   call setpos('.', pos)
 
-  let text = join(self.buffer.read(self.start, self.start), '\n')
+  let text = join(self.buffer.read(self.start_at, self.start_at), '\n')
   return substitute(text, '```', '', '')
 endf
 
 fun! s:fancy_text() dict abort
-  return self.buffer.read(self.start + 1, self.end - 1)
+  return self.buffer.read(self.start_at + 1, self.end_at - 1)
 endf
 
 fun! s:fancy_destroy() dict abort
@@ -166,6 +181,13 @@ fun! s:lookup_fancy(id)
   return found[0]
 endf
 
+fun! s:get_filetype_options(ft)
+  if has_key(g:fancy_filetypes, a:ft)
+    return g:fancy_filetypes[a:ft]
+  endif
+  return []
+endf
+
 fun! s:search_forward(pattern)
   return search(a:pattern, 'cnW')
 endf
@@ -174,10 +196,10 @@ fun! s:search_backward(pattern)
   return search(a:pattern, 'bcnW')
 endf
 
-fun! s:get_start_end_position()
-  let start = s:search_backward('^```\w\+$')
-  let end = s:search_forward('^```$')
-  return [start, end]
+fun! s:get_region_bounds(options)
+  let start_at = s:search_backward(a:options.start_at)
+  let end_at   = s:search_forward(a:options.end_at)
+  return [start_at, end_at]
 endf
 
 fun! s:edit()
@@ -216,16 +238,16 @@ fun! s:sync()
   endif
 
   " Sync any changes.
-  if (fancy.end - fancy.start > 1)
-    exe printf('%s,%s delete _', fancy.start + 1, fancy.end - 1)
+  if (fancy.end_at - fancy.start_at > 1)
+    exe printf('%s,%s delete _', fancy.start_at + 1, fancy.end_at - 1)
   endif
-  call append(fancy.start, buffer.read())
+  call append(fancy.start_at, buffer.read())
 
   " Restore the original cursor position.
   call setpos('.', fancy.buffer.pos)
 
   " Update start/end block position.
-  let [fancy.start, fancy.end] = s:get_start_end_position()
+  let [fancy.start_at, fancy.end_at] = s:get_region_bounds(fancy.options)
 endf
 
 fun! s:write()

--- a/plugin/fancy.vim
+++ b/plugin/fancy.vim
@@ -29,6 +29,10 @@ augroup END
 let github_flavored_markdown = {}
 let github_flavored_markdown.start_at = '^```\w\+$'
 let github_flavored_markdown.end_at = '^```$'
+fun! github_flavored_markdown.filetype(fancy)
+  let text = join(a:fancy.buffer.read(a:fancy.start_at, a:fancy.start_at), '\n')
+  return substitute(text, '```', '', '')
+endf
 
 let filetypes = {}
 let filetypes.markdown = [github_flavored_markdown]

--- a/plugin/fancy.vim
+++ b/plugin/fancy.vim
@@ -24,3 +24,15 @@ augroup fancy_markdown
 augroup END
 
 " }}}
+" Configuration {{{
+
+let github_flavored_markdown = {}
+let github_flavored_markdown.start_at = '^```\w\+$'
+let github_flavored_markdown.end_at = '^```$'
+
+let filetypes = {}
+let filetypes.markdown = [github_flavored_markdown]
+
+let g:fancy_filetypes = get(g:, 'fancy_filetypes', filetypes)
+
+" }}}

--- a/plugin/fancy.vim
+++ b/plugin/fancy.vim
@@ -1,8 +1,12 @@
+" Guard {{{
+
 if exists('g:loaded_fancy') || &cp || version < 700
   finish
 endif
 let g:loaded_fancy = 1
 
+" }}}
+" Autocommands {{{
 
 augroup fancy_files
   au!
@@ -14,8 +18,9 @@ augroup fancy_files
         \ nnore <buffer> q :write<bar>close<cr>
 augroup END
 
-
 augroup fancy_markdown
   au!
   au FileType markdown nnore <s-e> :call fancy#edit()<cr>
 augroup END
+
+" }}}


### PR DESCRIPTION
This PR add support of custom fenced block per filetype, and allow to refine existing rules via `vimrc`.

The `g:fancy_filetypes` has the following format:

``` vim
let g:fancy_filetypes = {
    \ 'filetype_a': [format_a, format_b],
    \ 'filetype_b': [format_c],
    \ }

let format_a = {
    \ 'start_at': start_of_the_block_regexp,
    \ 'end_at':   end_of_the_block_regexp,
    \ 'filetype': function_to_detect_filetype,
    \ }

fun! function_to_detect_filetype(fancy)
    return 'my_format'
endf
```

Note, that `function_to_detect_filetype` has access to `fancy` object.
