### PR TITLE
Indented fanced blocks

### DIFF
--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -24,6 +24,20 @@ fun! s:get_id()
   return s:id
 endf
 
+fun! s:indent_line(line, indent)
+  return printf('%*s%s', a:indent, a:indent ? ' ' : '', a:line)
+endf
+
+fun! s:dedent_line(line, indent)
+  return substitute(a:line, '^\s\{'.a:indent.'\}', '', '')
+endf
+
+fun! s:indent_lines(lines, indent)
+  return a:indent < 0 ?
+        \ map(lines, 's:dedent_line(v:val, indent)') :
+        \ map(lines, 's:indent_line(v:val, indent)')
+endf
+
 " }}}
 " Buffer prototype {{{
 
@@ -104,9 +118,18 @@ fun! s:buffer_write(...) dict abort
   return setline(lnum, text)
 endf
 
+fun! s:buffer_indent(...) dict abort
+  let indent = a:0 ? a:1 : 0
+  let start_at = (a:0 > 1) ? a:2 : 1
+  let end_at = (a:0 == 3) ? a:3 : '$'
+  return indent < 0 ?
+        \ map(self.read(start_at, end_at), 's:dedent_line(v:val, indent)') :
+        \ map(self.read(start_at, end_at), 's:indent_line(v:val, indent)')
+endf
+
 call s:add_methods('buffer', [
       \ 'getvar', 'setvar', 'name', 'delete', 'read', 'write',
-      \ 'exists', 'spec', 'path', 'fancy_id'
+      \ 'exists', 'spec', 'path', 'fancy_id', 'indent'
       \ ])
 
 " }}}
@@ -140,7 +163,8 @@ fun! s:fancy() abort
         \ 'options': search_options,
         \ 'start_at': start_at,
         \ 'end_at': end_at,
-        \ 'buffer': s:buffer()
+        \ 'buffer': s:buffer(),
+        \ 'indent_level': indent(start_at)
         \ }
   call extend(fancy, s:fancy_prototype, 'keep')
 
@@ -160,7 +184,10 @@ fun! s:fancy_filetype() dict abort
 endf
 
 fun! s:fancy_text() dict abort
-  return self.buffer.read(self.start_at + 1, self.end_at - 1)
+  return self.buffer.indent(
+        \ -self.indent_level,
+        \ self.start_at + 1,
+        \ self.end_at - 1)
 endf
 
 fun! s:fancy_destroy() dict abort
@@ -240,7 +267,7 @@ fun! s:sync(...)
   if (fancy.end_at - fancy.start_at > 1)
     exe printf('%s,%s delete _', fancy.start_at + 1, fancy.end_at - 1)
   endif
-  call append(fancy.start_at, buffer.read())
+  call append(fancy.start_at, buffer.indent(fancy.indent_level))
 
   " Restore the original cursor position.
   call setpos('.', fancy.buffer.pos)

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -219,14 +219,15 @@ fun! s:edit()
 endf
 
 fun! s:destroy(...)
-  let bufnr = a:0 ? str2nr(a:1[0]) : '%'
+  let bufnr = a:0 ? a:1[0] : '%'
   let buffer = s:buffer(bufnr)
   let fancy = s:lookup_fancy(buffer.fancy_id())
   call fancy.destroy()
 endf
 
-fun! s:sync()
-  let buffer = s:buffer()
+fun! s:sync(...)
+  let bufnr = a:0 ? a:1[0] : '%'
+  let buffer = s:buffer(bufnr)
   let fancy = s:lookup_fancy(buffer.fancy_id())
 
   " Go to original buffer.
@@ -248,8 +249,9 @@ fun! s:sync()
   let [fancy.start_at, fancy.end_at] = s:get_region_bounds(fancy.options)
 endf
 
-fun! s:write()
-  sil exe 'write! '.s:buffer().path()
+fun! s:write(...)
+  let bufnr = a:0 ? a:1[0] : '%'
+  sil exe 'write! '.s:buffer(bufnr).path()
   setl nomodified
 endf
 
@@ -265,11 +267,11 @@ fun! fancy#edit() abort
 endf
 
 fun! fancy#sync(...) abort
-  return s:sync()
+  return s:sync(a:000)
 endf
 
 fun! fancy#write(...) abort
-  return s:write()
+  return s:write(a:000)
 endf
 
 fun! fancy#destroy(...) abort

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -124,13 +124,12 @@ endf
 " - the indentation level (dedent buffer when value is negative and indent otherwise)
 " - the line number to start (read from the beginning if not set)
 " - the line number to end (process until the end if not set)
-fun! s:buffer_indent(...) dict abort
-  let indent   = a:0 ? a:1 : 0
-  let start_at = (a:0 > 1) ? a:2 : 1
-  let end_at   = (a:0 == 3) ? a:3 : '$'
-  return indent < 0 ?
-        \ map(self.read(start_at, end_at), 's:dedent_line(v:val, indent)') :
-        \ map(self.read(start_at, end_at), 's:indent_line(v:val, indent)')
+fun! s:buffer_indent(indent, ...) dict abort
+  let start_at = a:0 ? a:1 : 1
+  let end_at   = (a:0 > 1) ? a:2 : '$'
+  return a:indent < 0 ?
+        \ map(self.read(start_at, end_at), 's:dedent_line(v:val, a:indent)') :
+        \ map(self.read(start_at, end_at), 's:indent_line(v:val, a:indent)')
 endf
 
 call s:add_methods('buffer', [

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -118,6 +118,12 @@ fun! s:buffer_write(...) dict abort
   return setline(lnum, text)
 endf
 
+" Returns the buffer content with or without indentation.
+"
+" The arguments are:
+" - the indentation level (dedent buffer when value is negative and indent otherwise)
+" - the line number to start (read from the beginning if not set)
+" - the line number to end (process until the end if not set)
 fun! s:buffer_indent(...) dict abort
   let indent   = a:0 ? a:1 : 0
   let start_at = (a:0 > 1) ? a:2 : 1

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -33,9 +33,9 @@ fun! s:dedent_line(line, indent)
 endf
 
 fun! s:indent_lines(lines, indent)
-  return a:indent < 0 ?
-        \ map(lines, 's:dedent_line(v:val, indent)') :
-        \ map(lines, 's:indent_line(v:val, indent)')
+  return a:indent < 0
+        \ ? map(lines, 's:dedent_line(v:val, indent)')
+        \ : map(lines, 's:indent_line(v:val, indent)')
 endf
 
 " }}}
@@ -127,9 +127,9 @@ endf
 fun! s:buffer_indent(indent, ...) dict abort
   let start_at = a:0 ? a:1 : 1
   let end_at   = (a:0 > 1) ? a:2 : '$'
-  return a:indent < 0 ?
-        \ map(self.read(start_at, end_at), 's:dedent_line(v:val, a:indent)') :
-        \ map(self.read(start_at, end_at), 's:indent_line(v:val, a:indent)')
+  return a:indent < 0
+        \ ? map(self.read(start_at, end_at), 's:dedent_line(v:val, a:indent)')
+        \ : map(self.read(start_at, end_at), 's:indent_line(v:val, a:indent)')
 endf
 
 call s:add_methods('buffer', [

--- a/autoload/fancy.vim
+++ b/autoload/fancy.vim
@@ -119,9 +119,9 @@ fun! s:buffer_write(...) dict abort
 endf
 
 fun! s:buffer_indent(...) dict abort
-  let indent = a:0 ? a:1 : 0
+  let indent   = a:0 ? a:1 : 0
   let start_at = (a:0 > 1) ? a:2 : 1
-  let end_at = (a:0 == 3) ? a:3 : '$'
+  let end_at   = (a:0 == 3) ? a:3 : '$'
   return indent < 0 ?
         \ map(self.read(start_at, end_at), 's:dedent_line(v:val, indent)') :
         \ map(self.read(start_at, end_at), 's:indent_line(v:val, indent)')

--- a/plugin/fancy.vim
+++ b/plugin/fancy.vim
@@ -11,8 +11,8 @@ let g:loaded_fancy = 1
 augroup fancy_files
   au!
   au BufWriteCmd  fancy://**  call fancy#write(expand('<amatch>'))
-  au BufLeave     fancy://**  call fancy#sync()
-  au BufWipeout   fancy://**  call fancy#destroy(expand('<abuf>'))
+  au BufLeave     fancy://**  call fancy#sync(expand('<amatch>'))
+  au BufWipeout   fancy://**  call fancy#destroy(expand('<amatch>'))
   au BufEnter     fancy://**
         \ setl bufhidden=wipe bl noswapfile |
         \ nnore <buffer> q :write<bar>close<cr>

--- a/plugin/fancy.vim
+++ b/plugin/fancy.vim
@@ -27,11 +27,11 @@ augroup END
 " Configuration {{{
 
 let github_flavored_markdown = {}
-let github_flavored_markdown.start_at = '^```\w\+$'
-let github_flavored_markdown.end_at = '^```$'
+let github_flavored_markdown.start_at = '^\(\s\+\)\?```\w\+$'
+let github_flavored_markdown.end_at = '^\(\s\+\)\?```$'
 fun! github_flavored_markdown.filetype(fancy)
   let text = join(a:fancy.buffer.read(a:fancy.start_at, a:fancy.start_at), '\n')
-  return substitute(text, '```', '', '')
+  return substitute(text, '\(\s\+\)\?```', '', '')
 endf
 
 let bitbucket_markdown = {}


### PR DESCRIPTION
Detect indented fenced code blocks in markdown, for example, inside markdown list:

`````` markdown
Markdown list goes here:

- this item has fenced code block

    ```sh
    echo hi
    ```
``````
- [x] Detect indented fenced code blocks in gfm
- [x] Automatically indent/dedent block when sync changes between buffers
